### PR TITLE
Add 'Clean Jobs' to Delayed Jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 static/
 yarn-error.log
+*.rdb

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ function UI() {
   router.get('/queues', require('./routes/queues'))
   router.put('/queues/:queueName/retry', require('./routes/retryAll'))
   router.put('/queues/:queueName/:id/retry', require('./routes/retryJob'))
+  router.put('/queues/:queueName/clean', require('./routes/cleanAll'))
   router.get('/', require('./routes/index'))
 
   app.use(bodyParser.json())

--- a/routes/cleanAll.js
+++ b/routes/cleanAll.js
@@ -1,0 +1,23 @@
+module.exports = async function handler(req, res) {
+  try {
+    const { queueName } = req.params
+    const { queues } = req.app.locals
+
+    const GRACE_TIME_MS = 5000
+
+    const queue = queues[queueName]
+    if (!queue) {
+      return res.status(404).send({ error: 'queue not found' })
+    }
+
+    await queue.clean(GRACE_TIME_MS, 'delayed')
+
+    return res.sendStatus(200)
+  } catch (e) {
+    const body = {
+      error: 'queue error',
+      details: e.stack,
+    }
+    return res.status(500).send(body)
+  }
+}

--- a/ui/components/App.js
+++ b/ui/components/App.js
@@ -11,6 +11,7 @@ export default function App({ basePath }) {
     setSelectedStatuses,
     retryJob,
     retryAll,
+    cleanAll,
   } = useStore(basePath)
 
   return (
@@ -30,6 +31,7 @@ export default function App({ basePath }) {
                 selectStatus={setSelectedStatuses}
                 retryJob={retryJob(queue.name)}
                 retryAll={retryAll(queue.name)}
+                cleanAll={cleanAll(queue.name)}
               />
             ))}
           </>

--- a/ui/components/Queue.js
+++ b/ui/components/Queue.js
@@ -251,6 +251,9 @@ const actions = {
   failed: ({ retryAll }) => {
     return <button onClick={retryAll}>Retry all</button>
   },
+  delayed: ({ cleanAll }) => {
+    return <button onClick={cleanAll}>Clean all</button>
+  },
 }
 
 function QueueActions(props) {
@@ -269,6 +272,7 @@ function QueueActions(props) {
 export default function Queue({
   retryAll,
   retryJob,
+  cleanAll,
   queue,
   selectStatus,
   selectedStatus,
@@ -291,6 +295,7 @@ export default function Queue({
         <>
           <QueueActions
             retryAll={retryAll}
+            cleanAll={cleanAll}
             queue={queue}
             status={selectedStatus}
           />

--- a/ui/components/hooks/useStore.js
+++ b/ui/components/hooks/useStore.js
@@ -54,5 +54,17 @@ export default function useStore(basePath) {
       update,
     )
 
-  return { state, retryJob, retryAll, selectedStatuses, setSelectedStatuses }
+  const cleanAll = queueName => () =>
+    fetch(`${basePath}/queues/${queueName}/clean`, { method: 'put' }).then(
+      update,
+    )
+
+  return {
+    state,
+    retryJob,
+    retryAll,
+    cleanAll,
+    selectedStatuses,
+    setSelectedStatuses,
+  }
 }


### PR DESCRIPTION
There is now a button in the Delayed tab that cleans jobs.

It's difficult for me to test that this actually works.  Here's what I've been doing to test that this works:
1) Put the same Clean All button into failed jobs
2) Click it and verify that it moves the failed jobs into Waiting
This works.

Is there a simple way to create a test job that is Delayed, so I can test this more directly?

I've tried calling [moveToDelayed()](https://github.com/OptimalBits/bull/blob/develop/lib/job.js#L300) on newly created jobs, but that seems to move the jobs to Waiting rather than Delayed, so I can't test the Clean All button.  Or, perhaps it moves the jobs to the delayed status for a brief second, but they are immediately promoted to the waiting status for processing.  Either way, I can't test the Clean All button in the Delayed category.  Is there a way to force jobs to stay in the Delayed category?

Despite these difficulties with testing, I modeled this code verbatim after the 'Retry All' option that is available to Failed jobs.  The only difference is that the logic calls queue.clean() instead of job.retry().  Because the Clean All button moves jobs to Waiting when I place it in the Failed category, I believe it would work in the Delayed category.

I understand that this PR isn't ready to merge yet.  Any pointers would be appreciated.  Thank you very much.

closes #3 