### PR TITLE
code-highligthing: add pre-wrap property to break lines

### DIFF
--- a/ui/xcode.css
+++ b/ui/xcode.css
@@ -5,6 +5,7 @@ XCode style (c) Angel Garcia <angelgarcia.mail@gmail.com>
 */
 
 .hljs {
+  white-space: pre-wrap;
   display: block;
   overflow-x: auto;
   padding: 0.5em;


### PR DESCRIPTION
fixes #16 

breaks lines as expected: 

<img width="1300" alt="Screenshot 2019-09-23 at 17 19 16" src="https://user-images.githubusercontent.com/14620121/65439136-fad69080-de26-11e9-80d7-658e573b583e.png">
