### PR TITLE
job-progress: fix percentage value when gt 100

### DIFF
--- a/ui/components/Queue.js
+++ b/ui/components/Queue.js
@@ -166,6 +166,10 @@ const fieldComponents = {
           </Highlight>
         )
       case 'Number':
+        if (job.progress > 100) {
+          return <div className="progress-wrapper">{job.progress}</div>
+        }
+
         return (
           <div className="progress-wrapper">
             <div


### PR DESCRIPTION
jobs might have progress reports with values that are bigger than 100
this at least prevents the progress bar to break and instead show only the number

fixes #17