### PR TITLE
feat: use `proxyUrl` if provided

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -1,3 +1,4 @@
 module.exports = async (req, res) => {
-  res.render('index', { basePath: req.baseUrl })
+  const basePath = req.proxyUrl || req.baseUrl
+  res.render('index', { basePath })
 }


### PR DESCRIPTION
We want to be able to configure a different path from the one
mounted on Express router.
For example, if we use a reverse proxy that rewrite our path we
want to be able to load the UI.