### PR TITLE
Add support for bullmq (bull v4) and some small improvements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,43 +54,7 @@ setQueues([
 ])
 ```
 
-### Configure Queue(s) using bull-board
-
-You can also use bull-board itself to create the queues without the need for explicitly importing Bull.
-
-Remember that it depends on Redis as well, so the first step is to configure all of your queues:
-
-```js
-const { createQueues } = require('bull-board')
-
-const redisConfig = {
-  redis: {
-    port: process.env.REDIS_PORT,
-    host: process.env.REDIS_HOST,
-    password: process.env.REDIS_PASSWORD,
-  },
-}
-
-const queues = createQueues(redisConfig)
-```
-
-And then you can setup how your queues will work:
-
-```js
-const helloQueue = queues.add('helloQueue') // adds a queue
-const helloQueueWithOpts = queues.add('helloQueue', {
-  prefix: 'hello',
-}) // adds a queue with QueueOptions https://github.com/OptimalBits/bull/blob/master/REFERENCE.md#queue
-
-// defines how the queue works
-helloQueue.process(async job => {
-  console.log(`Hello ${job.data.hello}`)
-})
-
-helloQueue.add({ hello: 'world' }) // adds a job to the queue
-```
-
-And finally, add `UI` to your middlewares (this can be set up using an admin endpoint with some authentication method):
+You can then add `UI` to your middlewares (this can be set up using an admin endpoint with some authentication method):
 
 ```js
 const app = require('express')()
@@ -114,6 +78,8 @@ Just make sure you spin up a Redis instance locally (default port is 6379).
 ## Further ref
 
 For further ref, please check [Bull's docs](https://optimalbits.github.io/bull/). Apart from the way you configure and start your UI, this library doesn't hijack Bull's way of working.
+
+> Bull-board is also compatible with BullMQ (aka Bull4). You can learn more on [BullMQ's docs](https://docs.bullmq.io/).
 
 If you want to learn more about queues and Redis: https://redis.io/
 

--- a/example.js
+++ b/example.js
@@ -1,6 +1,6 @@
 const { setQueues, UI } = require('./')
-const { Queue3 } = require('bullmq/dist/classes/compat')
-const Queue = require('bull')
+const { Queue3: QueueMQ } = require('bullmq/dist/classes/compat')
+const Queue3 = require('bull')
 const app = require('express')()
 
 const sleep = t => new Promise(resolve => setTimeout(resolve, t * 1000))
@@ -12,16 +12,16 @@ const redisOptions = {
   tls: false,
 }
 
-const createQueue = name => new Queue(name, { redis: redisOptions })
-const createQueue4 = name => new Queue3(name, { connection: redisOptions })
+const createQueue3 = name => new Queue3(name, { redis: redisOptions })
+const createQueueMQ = name => new QueueMQ(name, { connection: redisOptions })
 
 const run = () => {
-  const example = createQueue('ExampleBull')
-  const exampleMQ = createQueue4('ExampleBullMQ')
+  const example3 = createQueue3('ExampleBull')
+  const exampleMQ = createQueueMQ('ExampleBullMQ')
 
-  setQueues([example, exampleMQ])
+  setQueues([example3, exampleMQ])
 
-  example.process(async job => {
+  example3.process(async job => {
     for (let i = 0; i <= 100; i++) {
       await sleep(Math.random())
       job.progress(i)
@@ -38,13 +38,13 @@ const run = () => {
   })
 
   app.use('/add', (req, res) => {
-    example.add({ title: req.query.title })
+    example3.add({ title: req.query.title })
     exampleMQ.add('Add', { title: req.query.title })
     res.json({ ok: true })
   })
 
   app.use('/ui', UI)
-  app.listen(3002, () => {
+  app.listen(3000, () => {
     console.log('Running on 3000...')
     console.log('For the UI, open http://localhost:3000/ui')
     console.log('Make sure Redis is running on port 6379 by default')

--- a/index.js
+++ b/index.js
@@ -1,15 +1,16 @@
-const Queue = require('bull')
 const express = require('express')
 const bodyParser = require('body-parser')
 const router = require('express-async-router').AsyncRouter()
 const path = require('path')
 
 const queues = {}
+const queuesVersions = {}
 
 function UI() {
   const app = express()
 
   app.locals.queues = queues
+  app.locals.queuesVersions = queuesVersions
 
   app.set('view engine', 'ejs')
   app.set('views', `${__dirname}/ui`)
@@ -18,7 +19,10 @@ function UI() {
   router.get('/queues', require('./routes/queues'))
   router.put('/queues/:queueName/retry', require('./routes/retryAll'))
   router.put('/queues/:queueName/:id/retry', require('./routes/retryJob'))
-  router.put('/queues/:queueName/clean/:queueStatus', require('./routes/cleanAll'))
+  router.put(
+    '/queues/:queueName/clean/:queueStatus',
+    require('./routes/cleanAll'),
+  )
   router.get('/', require('./routes/index'))
 
   app.use(bodyParser.json())
@@ -27,27 +31,35 @@ function UI() {
   return app
 }
 
+/**
+ * Return the version of the queue.
+ * Can be 3 (Bull3) or 4 (BullMQ).
+ * @param queue
+ */
+function getQueueVersion(queue) {
+  // Check for BullMQ Queue class
+  if (typeof queue.drain === 'function') {
+    return 4
+  }
+  // Check for BullMQ compat class
+  if (typeof queue.pauseWorker === 'function') {
+    return 4
+  }
+  return 3
+}
+
 module.exports = {
   UI: UI(),
-  setQueues: (bullQueues) => {
+  setQueues: bullQueues => {
     if (!Array.isArray(bullQueues)) {
-      bullQueues = [bullQueues];
+      bullQueues = [bullQueues]
     }
 
-    bullQueues.forEach((item) => {
-      queues[item.name] = item;
+    bullQueues.forEach(item => {
+      queues[item.name] = item
+      queuesVersions[item.name] = getQueueVersion(item)
     })
 
     return queues
-  },
-  createQueues: redis => {
-    return {
-      add: (name, opts) => {
-        const queue = new Queue(name, redis, opts)
-        queues[name] = queue
-
-        return queue
-      },
-    }
   },
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "body-parser": "^1.17.2",
-    "date-fns": "2.4.1",
+    "date-fns": "^2.9.0",
     "ejs": "^2.6.1",
     "express": "^4.15.2",
     "express-async-router": "^0.1.15",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "prepublishOnly": "rm -rf ./build && yarn build",
+    "prepare": "yarn build",
     "test": "node ./dockest.js",
     "build": "NODE_ENV=production webpack",
     "build:watch": "NODE_ENV=production webpack --watch",
@@ -28,7 +29,6 @@
   },
   "dependencies": {
     "body-parser": "^1.17.2",
-    "bull": "3.11.0",
     "date-fns": "2.4.1",
     "ejs": "^2.6.1",
     "express": "^4.15.2",
@@ -41,6 +41,8 @@
   },
   "devDependencies": {
     "babel-preset-react-app": "^7.0.2",
+    "bull": "^3.12.1",
+    "bullmq": "^1.6.6",
     "concurrently": "^4.1.2",
     "css-loader": "^2.1.1",
     "dockest": "^1.0.3",

--- a/routes/cleanAll.js
+++ b/routes/cleanAll.js
@@ -1,16 +1,21 @@
 module.exports = async function handler(req, res) {
   try {
     const { queueName, queueStatus } = req.params
-    const { queues } = req.app.locals
+    const { queues, queuesVersions } = req.app.locals
 
     const GRACE_TIME_MS = 5000
+    const LIMIT = 1000
 
     const queue = queues[queueName]
     if (!queue) {
       return res.status(404).send({ error: 'queue not found' })
     }
 
-    await queue.clean(GRACE_TIME_MS, queueStatus)
+    if (queuesVersions[queueName] === 4) {
+      await queue.clean(GRACE_TIME_MS, LIMIT, queueStatus)
+    } else {
+      await queue.clean(GRACE_TIME_MS, queueStatus)
+    }
 
     return res.sendStatus(200)
   } catch (e) {

--- a/routes/getDataForQeues.js
+++ b/routes/getDataForQeues.js
@@ -32,6 +32,7 @@ const formatJob = job => {
     stacktrace: job.stacktrace,
     opts: job.opts,
     data: job.data,
+    name: job.name,
   }
 }
 
@@ -39,7 +40,6 @@ const formatJobMQ = job => {
   return {
     ...formatJob(job),
     progress: job.progress,
-    name: job.name,
   }
 }
 

--- a/routes/queues.js
+++ b/routes/queues.js
@@ -1,9 +1,12 @@
 const getDataForQeues = require('./getDataForQeues')
 
 module.exports = async function handler(req, res) {
+  const { queuesVersions, queues } = req.app.locals
+
   res.json(
     await getDataForQeues({
-      queues: req.app.locals.queues,
+      queues,
+      queuesVersions,
       query: req.query,
     }),
   )

--- a/ui/components/Queue.js
+++ b/ui/components/Queue.js
@@ -171,6 +171,9 @@ const fieldComponents = {
     )
   },
   name: ({ job }) => {
+    if (job.name === '__default__') {
+      return '--'
+    }
     return job.name
   },
   finish: ({ job }) => {

--- a/ui/components/Queue.js
+++ b/ui/components/Queue.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { getYear, format, isToday, formatDistance, formatDistanceStrict } from 'date-fns'
 import { type } from 'ramda'
 import Highlight from 'react-highlight/lib/optimized'
@@ -54,13 +54,29 @@ const statuses = [
 ]
 
 const fields = {
-  latest: ['id', 'timestamps', 'progress', 'attempts', 'data', 'opts'],
-  completed: ['id', 'timestamps', 'progress', 'attempts', 'data', 'opts'],
-  delayed: ['id', 'timestamps', 'attempts', 'delay', 'data', 'opts'],
-  paused: ['id', 'timestamps', 'attempts', 'data', 'opts'],
-  active: ['id', 'timestamps', 'progress', 'attempts', 'data', 'opts'],
-  waiting: ['id', 'timestamps', 'data', 'opts'],
-  failed: ['id', 'failedReason', 'timestamps', 'progress', 'attempts', 'retry'],
+  latest: ['id', 'timestamps', 'name', 'progress', 'attempts', 'data', 'opts'],
+  completed: [
+    'id',
+    'timestamps',
+    'name',
+    'progress',
+    'attempts',
+    'data',
+    'opts',
+  ],
+  delayed: ['id', 'timestamps', 'name', 'attempts', 'delay', 'data', 'opts'],
+  paused: ['id', 'timestamps', 'name', 'attempts', 'data', 'opts'],
+  active: ['id', 'timestamps', 'name', 'progress', 'attempts', 'data', 'opts'],
+  waiting: ['id', 'timestamps', 'name', 'data', 'opts'],
+  failed: [
+    'id',
+    'failedReason',
+    'name',
+    'timestamps',
+    'progress',
+    'attempts',
+    'retry',
+  ],
 }
 
 function PlusIcon({ width = 18 }) {
@@ -154,6 +170,9 @@ const fieldComponents = {
       </div>
     )
   },
+  name: ({ job }) => {
+    return job.name
+  },
   finish: ({ job }) => {
     return <TS ts={job.finishedOn} prev={job.processedOn} />
   },
@@ -202,10 +221,15 @@ const fieldComponents = {
     )
   },
   data: ({ job }) => {
+    const [showData, toggleData] = useState(false)
+
     return (
-      <Highlight className="json">
-        {JSON.stringify(job.data, null, 2)}
-      </Highlight>
+      <>
+        <button onClick={() => toggleData(!showData)}>Toggle data</button>
+        <Highlight className="json">
+          {showData && JSON.stringify(job.data, null, 2)}
+        </Highlight>
+      </>
     )
   },
   opts: ({ job }) => {
@@ -290,7 +314,10 @@ export default function Queue({
 }) {
   return (
     <section>
-      <h3>{queue.name}</h3>
+      <h3>
+        {queue.name}
+        {queue.version === 4 && <small> bullmq</small>}
+      </h3>
       <div className="menu-list">
         {statuses.map(status => (
           <MenuItem

--- a/yarn.lock
+++ b/yarn.lock
@@ -2398,15 +2398,15 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.4.1.tgz#b53f9bb65ae6bd9239437035710e01cf383b625e"
-  integrity sha512-2RhmH/sjDSCYW2F3ZQxOUx/I7PvzXpi89aQL2d3OAxSTwLx6NilATeUbe0menFE3Lu5lFkOFci36ivimwYHHxw==
-
 date-fns@^1.30.1:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+
+date-fns@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.9.0.tgz#d0b175a5c37ed5f17b97e2272bbc1fa5aec677d2"
+  integrity sha512-khbFLu/MlzLjEzy9Gh8oY1hNt/Dvxw3J6Rbc28cVoYWQaC1S3YI4xwkF9ZWcjDLscbZlY9hISMr66RFzZagLsA==
 
 date-now@^0.1.4:
   version "0.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,6 +1050,13 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/ioredis@^4.0.13":
+  version "4.14.3"
+  resolved "https://registry.yarnpkg.com/@types/ioredis/-/ioredis-4.14.3.tgz#6a6089296d6fb90bbaee96d36b19d480efff026a"
+  integrity sha512-WM9xJkP+ckvr8DFy2bFEPWEp7454L/4cBT11qhqPqyzdyZ+8DxUfkf/yo+rQGQJbld0agY2PI5Jb3xxC7KZs6g==
+  dependencies:
+    "@types/node" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -1867,10 +1874,10 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-bull@3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/bull/-/bull-3.11.0.tgz#02782e3ff4afe80c0beb1a46bb09b76f178ee6d2"
-  integrity sha512-QQOn63RkL6CfnmZcacPVg1EF42SwQcYxNSn9OGlM5S2JW+Gah/dwCcXxZQ3h2nYnhsNfBsherJ7EpLzIsi2kSQ==
+bull@^3.12.1:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/bull/-/bull-3.12.1.tgz#ced62d0afca81c9264b44f1b6f39243df5d2e73f"
+  integrity sha512-X3bSP7gTqPXLYVSyUtQuTOqZuU0GwVbV304Et84Z8bxYP60R1VD3FUOLsESVRA9LIUEOWVH3hE8MFqlszmO0Gw==
   dependencies:
     cron-parser "^2.13.0"
     debuglog "^1.0.0"
@@ -1881,6 +1888,21 @@ bull@3.11.0:
     promise.prototype.finally "^3.1.1"
     semver "^6.3.0"
     util.promisify "^1.0.0"
+    uuid "^3.3.3"
+
+bullmq@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/bullmq/-/bullmq-1.6.6.tgz#b1e2161c83c019df0c63a86c2ba65856d00bae4c"
+  integrity sha512-Tj1BQG7WBmp++bll6Y3xC0omyii4SZ8WJQTTxa0LuPFxvoVyyffRKTqhvKExAdJEQllm20xKSjuDSjMfAH52+Q==
+  dependencies:
+    "@types/ioredis" "^4.0.13"
+    cron-parser "^2.7.3"
+    get-port "^5.0.0"
+    ioredis "^4.3.0"
+    lodash "^4.17.11"
+    node-uuid "^1.4.8"
+    semver "^6.3.0"
+    tslib "^1.10.0"
     uuid "^3.3.3"
 
 bytes@3.1.0:
@@ -2285,7 +2307,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cron-parser@^2.13.0:
+cron-parser@^2.13.0, cron-parser@^2.7.3:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-2.13.0.tgz#6f930bb6f2931790d2a9eec83b3ec276e27a6725"
   integrity sha512-UWeIpnRb0eyoWPVk+pD3TDpNx3KCFQeezO224oJIkktBrcW6RoAPOx5zIKprZGfk6vcYSmA8yQXItejSaDBhbQ==
@@ -3819,7 +3841,7 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
-ioredis@^4.14.1:
+ioredis@^4.14.1, ioredis@^4.3.0:
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.14.1.tgz#b73ded95fcf220f106d33125a92ef6213aa31318"
   integrity sha512-94W+X//GHM+1GJvDk6JPc+8qlM7Dul+9K+lg3/aHixPN7ZGkW6qlvX0DG6At9hWtH2v3B32myfZqWoANUJYGJA==
@@ -5121,6 +5143,11 @@ node-releases@^1.1.25, node-releases@^1.1.3:
   integrity sha512-AQw4emh6iSXnCpDiFe0phYcThiccmkNWMZnFZ+lDJjAP8J0m2fVd59duvUUyuTirQOhIAajTFkzG6FHCLBO59g==
   dependencies:
     semver "^5.3.0"
+
+node-uuid@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
+  integrity sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -6997,7 +7024,7 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
Hi,

I added support for bull v4 (#38). 

- Now, bull and bullmq are both optional peer dependencies and must be added by the user.
- The bull version is displayed on the dashboard
- For now, the `createQueues` function does not support bull 4

Unrelated (I can move it to another PR if you want), I added a button to toggle data instead of displaying it directly. In case of big data blob, the UI was freezing

closes #32 
closes #38 