### PR TITLE
feat: distance time for delayed jobs

### DIFF
--- a/ui/components/Queue.js
+++ b/ui/components/Queue.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { getYear, format, isToday, formatDistance } from 'date-fns'
+import { getYear, format, isToday, formatDistance, formatDistanceStrict } from 'date-fns'
 import { type } from 'ramda'
 import Highlight from 'react-highlight/lib/optimized'
 
@@ -191,7 +191,7 @@ const fieldComponents = {
     return job.attempts
   },
   delay: ({ job }) => {
-    return formatDistance(job.timestamp + job.delay, Date.now(), { options: { includeSeconds: true } })
+    return formatDistanceStrict(job.timestamp + job.delay, Date.now())
   },
   failedReason: ({ job }) => {
     return (

--- a/ui/components/Queue.js
+++ b/ui/components/Queue.js
@@ -191,7 +191,7 @@ const fieldComponents = {
     return job.attempts
   },
   delay: ({ job }) => {
-    return job.timestamp + job.delay - Date.now()
+    return formatDistance(job.timestamp + job.delay, Date.now(), { options: { includeSeconds: true } })
   },
   failedReason: ({ job }) => {
     return (


### PR DESCRIPTION
I've added a time format for delayed jobs. so it'll show a more human-readable time format instead of the remaining millisecond. for example, it shows `about 1 hour` instead of `3600000`.

a little technical choice here is that I used `formatDistance` instead of `formatDistanceToNow` as it was already imported in the `Queue.js` file. we can also use `formatDistanceStrict` which would give more exact timing (for example `43 minutes`). which one do you think users would be happier with?