### PR TITLE
Wrap encodeURIComponent to queueName in store methods

### DIFF
--- a/src/ui/components/hooks/useStore.ts
+++ b/src/ui/components/hooks/useStore.ts
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
 import qs from 'querystring'
-
 import { Status } from '../constants'
 import * as api from '../../../@types/api'
 import { AppQueue, AppJob } from '../../../@types/app'
@@ -65,14 +64,20 @@ export const useStore = (basePath: string): Store => {
       .then(data => setState({ data, loading: false }))
 
   const promoteJob = (queueName: string) => (job: AppJob) => () =>
-    fetch(`${basePath}/queues/${encodeURIComponent(queueName)}/${job.id}/promote`, {
-      method: 'put',
-    }).then(update)
+    fetch(
+      `${basePath}/queues/${encodeURIComponent(queueName)}/${job.id}/promote`,
+      {
+        method: 'put',
+      },
+    ).then(update)
 
   const retryJob = (queueName: string) => (job: AppJob) => () =>
-    fetch(`${basePath}/queues/${encodeURIComponent(queueName)}/${job.id}/retry`, {
-      method: 'put',
-    }).then(update)
+    fetch(
+      `${basePath}/queues/${encodeURIComponent(queueName)}/${job.id}/retry`,
+      {
+        method: 'put',
+      },
+    ).then(update)
 
   const retryAll = (queueName: string) => () =>
     fetch(`${basePath}/queues/${encodeURIComponent(queueName)}/retry`, {
@@ -90,9 +95,12 @@ export const useStore = (basePath: string): Store => {
     }).then(update)
 
   const cleanAllCompleted = (queueName: string) => () =>
-    fetch(`${basePath}/queues/${encodeURIComponent(queueName)}/clean/completed`, {
-      method: 'put',
-    }).then(update)
+    fetch(
+      `${basePath}/queues/${encodeURIComponent(queueName)}/clean/completed`,
+      {
+        method: 'put',
+      },
+    ).then(update)
 
   return {
     state,

--- a/src/ui/components/hooks/useStore.ts
+++ b/src/ui/components/hooks/useStore.ts
@@ -65,32 +65,32 @@ export const useStore = (basePath: string): Store => {
       .then(data => setState({ data, loading: false }))
 
   const promoteJob = (queueName: string) => (job: AppJob) => () =>
-    fetch(`${basePath}/queues/${queueName}/${job.id}/promote`, {
+    fetch(`${basePath}/queues/${encodeURIComponent(queueName)}/${job.id}/promote`, {
       method: 'put',
     }).then(update)
 
   const retryJob = (queueName: string) => (job: AppJob) => () =>
-    fetch(`${basePath}/queues/${queueName}/${job.id}/retry`, {
+    fetch(`${basePath}/queues/${encodeURIComponent(queueName)}/${job.id}/retry`, {
       method: 'put',
     }).then(update)
 
   const retryAll = (queueName: string) => () =>
-    fetch(`${basePath}/queues/${queueName}/retry`, {
+    fetch(`${basePath}/queues/${encodeURIComponent(queueName)}/retry`, {
       method: 'put',
     }).then(update)
 
   const cleanAllDelayed = (queueName: string) => () =>
-    fetch(`${basePath}/queues/${queueName}/clean/delayed`, {
+    fetch(`${basePath}/queues/${encodeURIComponent(queueName)}/clean/delayed`, {
       method: 'put',
     }).then(update)
 
   const cleanAllFailed = (queueName: string) => () =>
-    fetch(`${basePath}/queues/${queueName}/clean/failed`, {
+    fetch(`${basePath}/queues/${encodeURIComponent(queueName)}/clean/failed`, {
       method: 'put',
     }).then(update)
 
   const cleanAllCompleted = (queueName: string) => () =>
-    fetch(`${basePath}/queues/${queueName}/clean/completed`, {
+    fetch(`${basePath}/queues/${encodeURIComponent(queueName)}/clean/completed`, {
       method: 'put',
     }).then(update)
 


### PR DESCRIPTION
When you have "/" characters in queue names like:
@domain/queueName

Then UI will prepare requests like:
http://localhost:3000/ui/queues/@func/queueName/clean/failed

and server will resolve this as "404".

This fix uses urlEncode on queuName before we send request.
http://localhost:3000/ui/queues/%40func%2FqueueName/clean/failed

and server resolve with "200" status.

PS. I was use **encodeURIComponent()** instead of **qs.encode()** couse of compiling problems - need webpack reconfigurations.