### PR TITLE
feat: allow to replace queues completely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ yarn-error.log
 *.rdb
 website/build
 docker-compose.dockest-generated.yml
+dockest-error.json

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -8,6 +8,7 @@ describe('index', () => {
   it('should save the interface', () => {
     expect(bullBoard).toMatchInlineSnapshot(`
       Object {
+        "replaceQueues": [Function],
         "router": [Function],
         "setQueues": [Function],
       }
@@ -16,7 +17,7 @@ describe('index', () => {
 })
 
 describe('happy', () => {
-  const { router, setQueues } = bullBoard
+  const { router, setQueues, replaceQueues } = bullBoard
 
   it('should be able to set queue', async () => {
     const paintQueue = new Queue('Paint', {
@@ -58,6 +59,131 @@ describe('happy', () => {
                 },
                 "jobs": Array [],
                 "name": "bull:Paint:~",
+              },
+            ],
+            "stats": Object {
+              "blocked_clients": Any<String>,
+              "connected_clients": Any<String>,
+              "mem_fragmentation_ratio": Any<String>,
+              "redis_version": Any<String>,
+              "total_system_memory": Any<String>,
+              "used_memory": Any<String>,
+            },
+          }
+        `,
+        )
+      })
+  })
+
+  it('should be able to replace queues', async () => {
+    const paintQueue = new Queue('Paint', {
+      connection: {
+        host: 'localhost',
+        port: 6379,
+      },
+    })
+    const drainQueue = new Queue('Drain', {
+      connection: {
+        host: 'localhost',
+        port: 6379,
+      },
+    })
+    const codeQueue = new Queue('Code', {
+      connection: {
+        host: 'localhost',
+        port: 6379,
+      },
+    })
+
+    setQueues([paintQueue, drainQueue])
+    replaceQueues([codeQueue])
+
+    await request(router)
+      .get('/queues')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(res => {
+        expect(JSON.parse(res.text)).toMatchInlineSnapshot(
+          {
+            stats: {
+              blocked_clients: expect.any(String),
+              connected_clients: expect.any(String),
+              mem_fragmentation_ratio: expect.any(String),
+              redis_version: expect.any(String),
+              total_system_memory: expect.any(String),
+              used_memory: expect.any(String),
+            },
+          },
+          `
+          Object {
+            "queues": Array [
+              Object {
+                "counts": Object {
+                  "active": 0,
+                  "completed": 0,
+                  "delayed": 0,
+                  "failed": 0,
+                  "paused": 0,
+                  "waiting": 0,
+                },
+                "jobs": Array [],
+                "name": "bull:Code:~",
+              },
+            ],
+            "stats": Object {
+              "blocked_clients": Any<String>,
+              "connected_clients": Any<String>,
+              "mem_fragmentation_ratio": Any<String>,
+              "redis_version": Any<String>,
+              "total_system_memory": Any<String>,
+              "used_memory": Any<String>,
+            },
+          }
+        `,
+        )
+      })
+  })
+
+  it('should be able to replace queues without initial set', async () => {
+    const codeQueue = new Queue('Code', {
+      connection: {
+        host: 'localhost',
+        port: 6379,
+      },
+    })
+
+    replaceQueues([codeQueue])
+
+    await request(router)
+      .get('/queues')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(res => {
+        expect(JSON.parse(res.text)).toMatchInlineSnapshot(
+          {
+            stats: {
+              blocked_clients: expect.any(String),
+              connected_clients: expect.any(String),
+              mem_fragmentation_ratio: expect.any(String),
+              redis_version: expect.any(String),
+              total_system_memory: expect.any(String),
+              used_memory: expect.any(String),
+            },
+          },
+          `
+          Object {
+            "queues": Array [
+              Object {
+                "counts": Object {
+                  "active": 0,
+                  "completed": 0,
+                  "delayed": 0,
+                  "failed": 0,
+                  "paused": 0,
+                  "waiting": 0,
+                },
+                "jobs": Array [],
+                "name": "bull:Code:~",
               },
             ],
             "stats": Object {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,9 @@ router.put('/queues/:queueName/:id/retry', wrapAsync(retryJob))
 router.put('/queues/:queueName/:id/promote', wrapAsync(promoteJob))
 router.put('/queues/:queueName/clean/:queueStatus', wrapAsync(cleanAll))
 
-export const setQueues = (bullQueues: Queue[] | QueueMq[]) => {
+type Q = Queue | QueueMq
+
+export const setQueues = (bullQueues: ReadonlyArray<Q>) => {
   bullQueues.forEach((queue: Queue | QueueMq) => {
     const name = queue instanceof QueueMq ? queue.toKey('~') : queue.name
 
@@ -42,6 +44,18 @@ export const setQueues = (bullQueues: Queue[] | QueueMq[]) => {
       queue,
     }
   })
+}
+
+export const replaceQueues = (bullQueues: ReadonlyArray<Q>) => {
+  const queuesToPersist: string[] = bullQueues.map(queue => queue.name)
+
+  Object.keys(bullBoardQueues).forEach(name => {
+    if (queuesToPersist.indexOf(name) === -1) {
+      delete bullBoardQueues[name]
+    }
+  })
+
+  return setQueues(bullQueues)
 }
 
 export { router }


### PR DESCRIPTION
This target to sync 1:1 queues that are available in-app and in bull-board.

The pseudocode here is

```ts
const queues = [];

setQueues(queues);

app.use("/", UI);

app.post("/queues", (req, res) => {
  queues.push(new Queue(...req.body));

  setQueues(queues); // this one is ok, we're adding a queue
});

app.delete("/queues/:id", () => {
  queues.splice(req.params.id, 1);

  // setQueues(queues); // this one will not work, because it doesn't perform a removal
  replaceQueues(queues);
});
```