### PR TITLE
Add type locations in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "Erik Engervall <erik.engervall@gmail.com>"
   ],
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Webpack is currently outputting the types to dist/index.d.ts, but isn't being referenced by package.json. This causes vscode to recommend to me to install @types/bull-board, which contains incorrect typings for the project.