### PR TITLE
Add Pagination for Jobs List

### DIFF
--- a/routes/getDataForQeues.js
+++ b/routes/getDataForQeues.js
@@ -51,8 +51,6 @@ module.exports = async function getDataForQeues({ queues, query = {} }) {
     return { stats: {}, queues: [] }
   }
 
-  console.log('query', query)
-
   const pairs = Object.entries(queues)
 
   const counts = await Promise.all(

--- a/routes/getDataForQeues.js
+++ b/routes/getDataForQeues.js
@@ -49,6 +49,8 @@ module.exports = async function getDataForQeues({ queues, query = {} }) {
     return { stats: {}, queues: [] }
   }
 
+  console.log('query', query)
+
   const pairs = Object.entries(queues)
 
   const counts = await Promise.all(
@@ -58,7 +60,19 @@ module.exports = async function getDataForQeues({ queues, query = {} }) {
       let jobs = []
       if (name) {
         const status = query[name] === 'latest' ? statuses : query[name]
-        jobs = await queue.getJobs(status, 0, 10)
+        let start = 0
+        let end = 10
+        if (query.start && query.end) {
+          const parsedStart = parseInt(query.start)
+          const parsedEnd = parseInt(query.end)
+          if (parsedStart !== NaN) {
+            start = parsedStart
+          }
+          if (parsedEnd !== NaN) {
+            end = parsedEnd
+          }
+        }
+        jobs = await queue.getJobs(status, start, end)
       }
 
       return {

--- a/routes/getDataForQeues.js
+++ b/routes/getDataForQeues.js
@@ -1,5 +1,7 @@
 const { pick, isEmpty } = require('ramda')
 
+const getPaginationParameters = require('./pagination')
+
 const metrics = [
   'redis_version',
   'used_memory',
@@ -60,19 +62,10 @@ module.exports = async function getDataForQeues({ queues, query = {} }) {
       let jobs = []
       if (name) {
         const status = query[name] === 'latest' ? statuses : query[name]
-        let start = 0
-        let end = 10
-        if (query.start && query.end) {
-          const parsedStart = parseInt(query.start)
-          const parsedEnd = parseInt(query.end)
-          if (parsedStart !== NaN) {
-            start = parsedStart
-          }
-          if (parsedEnd !== NaN) {
-            end = parsedEnd
-          }
-        }
-        jobs = await queue.getJobs(status, start, end)
+        
+        const [paginationStartIndex, paginationEndIndex] = getPaginationParameters(query)
+
+        jobs = await queue.getJobs(status, paginationStartIndex, paginationEndIndex)
       }
 
       return {
@@ -86,3 +79,4 @@ module.exports = async function getDataForQeues({ queues, query = {} }) {
 
   return { stats, queues: counts }
 }
+

--- a/routes/pagination.js
+++ b/routes/pagination.js
@@ -1,4 +1,4 @@
-export const getPaginationParameters = query => {
+module.exports = function getPaginationParameters(query) {
   let start = 0
   let end = 9
   if (query.start && query.end) {

--- a/routes/pagination.js
+++ b/routes/pagination.js
@@ -1,0 +1,16 @@
+export const getPaginationParameters = query => {
+  let start = 0
+  let end = 9
+  if (query.start && query.end) {
+    const parsedStart = parseInt(query.start)
+    const parsedEnd = parseInt(query.end)
+    if (parsedStart !== NaN) {
+      start = parsedStart
+    }
+    if (parsedEnd !== NaN) {
+      end = parsedEnd
+    }
+  }
+
+  return [start, end]
+}

--- a/ui/components/App.js
+++ b/ui/components/App.js
@@ -9,6 +9,8 @@ export default function App({ basePath }) {
     state,
     selectedStatuses,
     setSelectedStatuses,
+    pagination,
+    setPagination,
     retryJob,
     retryAll,
     cleanAllDelayed,
@@ -30,6 +32,8 @@ export default function App({ basePath }) {
                 key={queue.name}
                 selectedStatus={selectedStatuses[queue.name]}
                 selectStatus={setSelectedStatuses}
+                pagination={pagination}
+                setPagination={setPagination}
                 retryJob={retryJob(queue.name)}
                 retryAll={retryAll(queue.name)}
                 cleanAllDelayed={cleanAllDelayed(queue.name)}

--- a/ui/components/Paginator.js
+++ b/ui/components/Paginator.js
@@ -1,0 +1,91 @@
+import React, { useState, useEffect } from 'react'
+
+export const Paginator = ({
+  pagination,
+  setPagination,
+  totalJobs,
+}) => {
+  const totalPages = Math.ceil(totalJobs / 10)
+  const currentPageNumber = totalJobs > 0 ? Math.floor(pagination.start / 10) + 1 : 0
+
+  const [pageNumberInputValue, setPageNumberInputValue] = useState(currentPageNumber)
+
+  useEffect(() => {
+    setPageNumberInputValue(currentPageNumber)
+  }, [currentPageNumber])
+
+  const handleClickPrevPage = (event) => {
+    if (pagination.start >= 10) {
+      setPagination({
+        start: pagination.start - 10,
+        end: pagination.end - 10,
+      })
+    }
+  }
+
+  const handleClickNextPage = (event) => {
+    if (currentPageNumber < totalPages) {
+      setPagination({
+        start: pagination.start + 10,
+        end: pagination.end + 10,
+      })
+    }
+  }
+
+  const handlePageNumberInputSubmit = (event) => {
+    if (event.key !== 'Enter') {
+      return
+    }
+
+    const inputValue = parseInt(pageNumberInputValue)
+    if (inputValue !== NaN) {
+      if (inputValue > 0 && inputValue <= totalPages) {
+        const startIndex = (inputValue - 1) * 10
+        const endIndex = startIndex + (Math.min(Math.max(totalJobs - 1, 0), 9))
+        setPagination({
+          start: (inputValue - 1) * 10,
+          end: endIndex,
+        })
+      } else {
+        alert(`Invalid page number. Please input a number between 1 and ${totalPages}`)
+        setPageNumberInputValue(currentPageNumber)
+      }
+    }
+  }
+
+  const handlePageNumberInputChange = (event) => {
+    setPageNumberInputValue(event.target.value)
+  }
+
+  return (
+    <div className="paginator">
+      <div>
+        <button
+          disabled={pagination.start < 10}
+          role="button"
+          onClick={handleClickPrevPage}
+        >
+          Prev
+        </button>
+        
+        <button
+          disabled={currentPageNumber >= totalPages}
+          role="button"
+          onClick={handleClickNextPage}
+        >
+          Next
+        </button>
+      </div>
+      <div>
+        Page <input
+          disabled={totalPages === 0}
+          className="page-number" 
+          type="number" 
+          onKeyDown={handlePageNumberInputSubmit} 
+          onChange={handlePageNumberInputChange} 
+          value={pageNumberInputValue} /> out of {totalPages} pages. Listing the first{' '}
+        {pagination.start} - {Math.min(pagination.end, totalJobs)} jobs.
+      </div>
+    </div>
+  )
+}

--- a/ui/components/hooks/useStore.js
+++ b/ui/components/hooks/useStore.js
@@ -9,6 +9,8 @@ export default function useStore(basePath) {
     loading: true,
   })
   const [selectedStatuses, setSelectedStatuses] = useState({})
+  const [paginationStartIndex, setPaginationStartIndex] = useState(0)
+  const [paginationEndIndex, setPaginationEndIndex] = useState(10)
 
   const poll = useRef()
 
@@ -72,5 +74,7 @@ export default function useStore(basePath) {
     cleanAllFailed,
     selectedStatuses,
     setSelectedStatuses,
+    setPaginationStartIndex,
+    setPaginationEndIndex
   }
 }

--- a/ui/components/hooks/useStore.js
+++ b/ui/components/hooks/useStore.js
@@ -9,8 +9,10 @@ export default function useStore(basePath) {
     loading: true,
   })
   const [selectedStatuses, setSelectedStatuses] = useState({})
-  const [paginationStartIndex, setPaginationStartIndex] = useState(0)
-  const [paginationEndIndex, setPaginationEndIndex] = useState(10)
+  const [pagination, setPagination] = useState({
+    start: 0,
+    end: 9,
+  })
 
   const poll = useRef()
 
@@ -18,7 +20,7 @@ export default function useStore(basePath) {
     stopPolling()
     runPolling()
     return stopPolling
-  }, [selectedStatuses])
+  }, [selectedStatuses, pagination])
 
   const stopPolling = () => {
     if (poll.current) {
@@ -41,7 +43,10 @@ export default function useStore(basePath) {
   }
 
   const update = () => {
-    return fetch(`${basePath}/queues/?${qs.encode(selectedStatuses)}`)
+    return fetch(`${basePath}/queues/?${qs.encode(Object.entries(selectedStatuses).length ? {
+      ...selectedStatuses,
+      ...pagination,
+    } : {})}`)
       .then(res => (res.ok ? res.json() : Promise.reject(res)))
       .then(data => setState({ data, loading: false }))
   }
@@ -74,7 +79,7 @@ export default function useStore(basePath) {
     cleanAllFailed,
     selectedStatuses,
     setSelectedStatuses,
-    setPaginationStartIndex,
-    setPaginationEndIndex
+    pagination,
+    setPagination,
   }
 }

--- a/ui/index.css
+++ b/ui/index.css
@@ -73,7 +73,7 @@ a {
 
 table {
   width: 100%;
-  padding: 40px;
+  padding: 40px 40px 0px 40px;
 }
 
 td {
@@ -216,6 +216,12 @@ button:active {
   top: 1px;
 }
 
+button:disabled {
+  background-color: whitesmoke;
+  color: gray;
+  cursor: not-allowed;
+}
+
 /* Progress bar */
 
 .progress-wrapper {
@@ -228,4 +234,25 @@ button:active {
   border-right: 2px solid rgba(0, 0, 0, 0.1);
   text-align: right;
   color: #070;
+}
+
+/* Paginator */
+
+.paginator {
+  text-align: center;
+  padding: 10px;
+}
+
+.paginator button,
+.paginator span {
+  margin: 4px 4px 0 0;
+}
+
+.paginator input.page-number {
+  width: 4em;
+  font-size: 1em;
+}
+.paginator input.page-number:disabled {
+  color: gray;
+  cursor: not-allowed;
 }


### PR DESCRIPTION
Implements #37 

## This PR contains
- Prev / Next buttons for navigating pages
- Jump to page by number input, easier to inspect later on jobs when job list is large. (press enter to take effect - perhaps not so intuitive, but comparing to taking effect on every typing changes, this approach would save unnecessary request on redis. But any feedback are welcome)
- User input validation & error prevention
- Pagination boundary checks

## Screenshot

![image](https://user-images.githubusercontent.com/15918424/82972207-509ca300-9f89-11ea-9eb4-050b46196c4f.png)


This PR is based on the javascript version (`0.6.0`) to avoid wait on the latest TypeScript rewrite ([see discussion](https://github.com/vcapretz/bull-board/issues/37#issuecomment-633896558)), therefore this PR can only be merged to version `0.6.0` and not the latest alpha version. But once the project moves forward probably will need to refactor this ticket into TypeScript as well.

In case anyone wants to try use it in your project you can install by `yarn install @shaungc/bull-board@0.6.0--debug-01`.