### PR TITLE
Toggle id display for job

### DIFF
--- a/src/ui/components/Job.tsx
+++ b/src/ui/components/Job.tsx
@@ -15,7 +15,26 @@ type FieldProps = {
 }
 
 const fieldComponents: Record<Field, React.FC<FieldProps>> = {
-  id: ({ job }) => <b>#{job.id}</b>,
+  id: ({ job }) => {
+    const displayTruncate = job.id && String(job.id).length > 10
+    const truncatedId = String(job.id).slice(0, 0)
+    const [showId, toggleId] = useState(false)
+
+    return (
+      <>
+        {displayTruncate ? (
+          <>
+            <button onClick={() => toggleId(!showId)}>Show full id</button>
+            <div style={{ fontWeight: 'bold' }}>
+              {showId ? job.id : truncatedId}
+            </div>
+          </>
+        ) : (
+          <b>{job.id}</b>
+        )}
+      </>
+    )
+  },
 
   timestamps: ({ job }) => (
     <div className="timestamps">

--- a/src/ui/components/Job.tsx
+++ b/src/ui/components/Job.tsx
@@ -16,21 +16,21 @@ type FieldProps = {
 
 const fieldComponents: Record<Field, React.FC<FieldProps>> = {
   id: ({ job }) => {
-    const displayTruncate = job.id && String(job.id).length > 10
-    const truncatedId = String(job.id).slice(0, 0)
+    const displayShortId = job.id && String(job.id).length > 10
+    const shortId = `${String(job.id).slice(0, 6)}...`
     const [showId, toggleId] = useState(false)
 
     return (
       <>
-        {displayTruncate ? (
+        {displayShortId ? (
           <>
-            <button onClick={() => toggleId(!showId)}>Show full id</button>
+            <button onClick={() => toggleId(!showId)}>Toggle full id</button>
             <div style={{ fontWeight: 'bold' }}>
-              {showId ? job.id : truncatedId}
+              #{showId ? job.id : shortId}
             </div>
           </>
         ) : (
-          <b>{job.id}</b>
+          <b>#{job.id}</b>
         )}
       </>
     )


### PR DESCRIPTION
Having sometimes very long ids for our jobs, it messes up with the UI and shifts all the content to the right side.

<img width="800" alt="long-id-example" src="https://user-images.githubusercontent.com/10398565/87164902-a8893200-c2c9-11ea-8256-4235b0841a39.png">

A workaround we found is having the possibility to toggle the `id` data when it's too long, the same way you can toggle `json` data for jobs.


