### PR TITLE
improve support for domains which reject inline scripts

### DIFF
--- a/ui/index.ejs
+++ b/ui/index.ejs
@@ -9,10 +9,7 @@
     <title>Bull Dashboard</title>
   </head>
   <body>
-    <div id="root">Loading...</div>
-    <script>
-      window.basePath = '<%= basePath %>'
-    </script>
+    <div id="root" data-base-path="<%= basePath %>">Loading...</div>
     <script src="<%= basePath %>/static/bundle.js"></script>
   </body>
 </html>

--- a/ui/index.js
+++ b/ui/index.js
@@ -4,4 +4,7 @@ import './index.css'
 import './xcode.css'
 import App from './components/App'
 
-render(<App basePath={window.basePath} />, document.getElementById('root'))
+const root = document.getElementById('root');
+const basePath = root.dataset.basePath;
+
+render(<App basePath={basePath} />, root)


### PR DESCRIPTION
This is a minor change that moves the `basePath` from a write to `window.basePath` and into an attribute on the root element so that domains which use CSP to prevent inline scripts will be able to use bull-board.

This PR is to the latest-stable branch but I'd be happy to submit it to master and backport it to latest-stable.