### PR TITLE
add null check when job is undefined

### DIFF
--- a/routes/getDataForQeues.js
+++ b/routes/getDataForQeues.js
@@ -70,7 +70,7 @@ module.exports = async function getDataForQeues({ queues, query = {} }) {
       return {
         name,
         counts,
-        jobs: jobs.map(formatJob),
+        jobs: jobs.filter((job) => !!job).map(formatJob),
       }
     }),
   )


### PR DESCRIPTION
This fixes a case where bull returns `null` for a job. I am not sure why bull does that but this PR adds a null check to prevent the app from crashing

fixes #43 