### PR TITLE
Read base path from <base>, removes the inline scripts

### DIFF
--- a/src/ui/index.ejs
+++ b/src/ui/index.ejs
@@ -6,13 +6,11 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <base href="<%= basePath %>"/>
     <title>Bull Dashboard</title>
     <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root">Loading...</div>
-    <script>
-      window.basePath = '<%= basePath %>'
-    </script>
   </body>
 </html>

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -5,8 +5,6 @@ import './index.css'
 import './theme.css'
 import { App } from './components/App'
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-const basePath = window.basePath
+const basePath = document.head.querySelector('base')?.getAttribute('href') || ''
 
 render(<App basePath={basePath} />, document.getElementById('root'))


### PR DESCRIPTION
This pr passed the basePath to <base> tag, it removes the need for inline script.

fixes #91 & #130 