### PR TITLE
fix: "Cannot assign to read only property 'exports'" error

### DIFF
--- a/src/ui/components/Highlight/Highlight.tsx
+++ b/src/ui/components/Highlight/Highlight.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
-import hljs from 'highlight.js/lib/highlight'
+import hljs from 'highlight.js/lib/core'
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import json from 'highlight.js/lib/languages/json'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
+        exclude: /node_modules/,
         options: { presets: ['react-app'] },
       },
       {
@@ -82,10 +83,6 @@ module.exports = {
         basePath,
       },
     }),
-    new webpack.ContextReplacementPlugin(
-      /highlight.js\/lib\/languages$/,
-      /^.\/(json|javascript)$/,
-    ),
     new ForkTsCheckerWebpackPlugin(),
   ],
   optimization: {


### PR DESCRIPTION
Make the build much faster by excluding `node_modules` from babel-loader