### PR TITLE
Handle better return type lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
     'no-console': 'warn',
     'no-only-tests/no-only-tests': 'error',
     '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-empty-interface': 'off',
@@ -41,4 +42,13 @@ module.exports = {
     'react/prop-types': 'off',
     'react/display-name': 'off',
   },
+  overrides: [
+    {
+      // enable the rule specifically for TypeScript files
+      files: ['*.ts'],
+      rules: {
+        '@typescript-eslint/explicit-module-boundary-types': ['warn'],
+      },
+    },
+  ],
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ router.put('/api/queues/:queueName/:id/clean', wrapAsync(cleanJob))
 router.put('/api/queues/:queueName/:id/promote', wrapAsync(promoteJob))
 router.put('/api/queues/:queueName/clean/:queueStatus', wrapAsync(cleanAll))
 
-export const setQueues = (bullQueues: ReadonlyArray<QueueAdapter>) => {
+export const setQueues = (bullQueues: ReadonlyArray<QueueAdapter>): void => {
   bullQueues.forEach((queue) => {
     const name = queue.getName()
 
@@ -45,7 +45,9 @@ export const setQueues = (bullQueues: ReadonlyArray<QueueAdapter>) => {
   })
 }
 
-export const replaceQueues = (bullQueues: ReadonlyArray<QueueAdapter>) => {
+export const replaceQueues = (
+  bullQueues: ReadonlyArray<QueueAdapter>,
+): void => {
   const queuesToPersist: string[] = bullQueues.map((queue) => queue.getName())
 
   Object.keys(bullBoardQueues).forEach((name) => {

--- a/src/queueAdapters/bull.ts
+++ b/src/queueAdapters/bull.ts
@@ -7,7 +7,7 @@ import {
 } from '../@types/app'
 
 export class BullAdapter implements QueueAdapter {
-  public get client() {
+  public get client(): Promise<Queue['client']> {
     return Promise.resolve(this.queue.client)
   }
 

--- a/src/queueAdapters/bullMQ.ts
+++ b/src/queueAdapters/bullMQ.ts
@@ -1,5 +1,4 @@
 import { Job, Queue } from 'bullmq'
-import * as Redis from 'ioredis'
 import {
   JobCleanStatus,
   JobCounts,
@@ -10,8 +9,8 @@ import {
 export class BullMQAdapter implements QueueAdapter {
   private readonly LIMIT = 1000
 
-  public get client() {
-    return (this.queue.client as unknown) as Promise<Redis.Redis>
+  public get client(): Queue['client'] {
+    return this.queue.client
   }
 
   constructor(private queue: Queue) {}

--- a/src/ui/components/Highlight/languages/stacktrace.ts
+++ b/src/ui/components/Highlight/languages/stacktrace.ts
@@ -4,7 +4,7 @@ Author: FelixMosh
 Description: Node stacktrace highlighter
 */
 
-export function stacktraceJS() {
+export function stacktraceJS(): any {
   const ERROR = {
     className: 'type',
     begin: /^\w*Error:\s*/,

--- a/src/ui/hooks/useScrolled.ts
+++ b/src/ui/hooks/useScrolled.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 
-export const useScrolled = () => {
+export const useScrolled = (): boolean => {
   const [scrolled, setScrolled] = useState(
     typeof window === 'undefined' ? false : window.scrollY > 20,
   )


### PR DESCRIPTION
This PR fixes all lint warnings related to return type, disables it on `.tsx` file type