### PR TITLE
Add read only mode, closes #219

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ app.use('/admin/queues', router)
 
 That's it! Now you can access the `/admin/queues` route and you will be able to monitor everything that is happening in your queues 😁
 
+### Queue options
+1. `readOnlyMode` (default: `false`)
+Makes the UI as read only,hides all queue & jobs related actions
+   ```js
+    const Queue = require('bull')
+    const QueueMQ = require('bullmq')
+    const { setQueues, BullMQAdapter, BullAdapter } = require('bull-board')
+    
+    const someQueue = new Queue()
+    const someOtherQueue = new Queue()
+    const queueMQ = new QueueMQ()
+    
+    setQueues([
+      new BullAdapter(someQueue, { readOnlyMode: true }), // only this queue will be in read only mode
+      new BullAdapter(someOtherQueue),
+      new BullMQAdapter(queueMQ),
+    ]);
+   ```
+
 ### Hosting router on a sub path
 
 If you host your express service on a different path than root (/) ie. https://<server_name>/<sub_path>/, then you can add the following code to provide the configuration to the bull-board router. In this example the sub path will be `my-base-path`.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ That's it! Now you can access the `/admin/queues` route and you will be able to 
 
 ### Queue options
 1. `readOnlyMode` (default: `false`)
-Makes the UI as read only,hides all queue & jobs related actions
+Makes the UI as read only, hides all queue & job related actions
    ```js
     const Queue = require('bull')
     const QueueMQ = require('bullmq')
@@ -91,7 +91,7 @@ Makes the UI as read only,hides all queue & jobs related actions
     setQueues([
       new BullAdapter(someQueue, { readOnlyMode: true }), // only this queue will be in read only mode
       new BullAdapter(someOtherQueue),
-      new BullMQAdapter(queueMQ),
+      new BullMQAdapter(queueMQ, { readOnlyMode: true }),
     ]);
    ```
 

--- a/src/@types/app.ts
+++ b/src/@types/app.ts
@@ -17,6 +17,8 @@ export type JobCounts = Record<JobStatus, number>
 
 export interface QueueAdapter {
   readonly client: Promise<Redis.Redis>
+  readonly readOnlyMode: boolean
+
   getName(): string
 
   getJob(id: string): Promise<Job | JobMq | undefined | null>
@@ -30,6 +32,10 @@ export interface QueueAdapter {
   getJobCounts(...jobStatuses: JobStatus[]): Promise<JobCounts>
 
   clean(queueStatus: JobCleanStatus, graceTimeMs: number): Promise<any>
+}
+
+export interface QueueAdapterOptions {
+  readOnlyMode: boolean
 }
 
 export interface BullBoardQueue {
@@ -69,6 +75,7 @@ export interface AppQueue {
   name: string
   counts: Record<Status, number>
   jobs: AppJob[]
+  readOnlyMode: boolean
 }
 
 export type SelectedStatuses = Record<AppQueue['name'], Status>

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -63,6 +63,7 @@ describe('happy', () => {
                 },
                 "jobs": Array [],
                 "name": "bull:Paint:~",
+                "readOnlyMode": false,
               },
             ],
             "stats": Object {
@@ -138,6 +139,7 @@ describe('happy', () => {
                 },
                 "jobs": Array [],
                 "name": "bull:Code:~",
+                "readOnlyMode": false,
               },
             ],
             "stats": Object {
@@ -196,6 +198,7 @@ describe('happy', () => {
                 },
                 "jobs": Array [],
                 "name": "bull:Code:~",
+                "readOnlyMode": false,
               },
             ],
             "stats": Object {

--- a/src/queueAdapters/bull.ts
+++ b/src/queueAdapters/bull.ts
@@ -4,14 +4,19 @@ import {
   JobCounts,
   JobStatus,
   QueueAdapter,
+  QueueAdapterOptions,
 } from '../@types/app'
 
 export class BullAdapter implements QueueAdapter {
+  public readonly readOnlyMode: boolean
+
   public get client(): Promise<Queue['client']> {
     return Promise.resolve(this.queue.client)
   }
 
-  constructor(public queue: Queue) {}
+  constructor(public queue: Queue, options: Partial<QueueAdapterOptions> = {}) {
+    this.readOnlyMode = options.readOnlyMode === true
+  }
 
   public getName(): string {
     return this.queue.name

--- a/src/queueAdapters/bullMQ.ts
+++ b/src/queueAdapters/bullMQ.ts
@@ -4,16 +4,23 @@ import {
   JobCounts,
   JobStatus,
   QueueAdapter,
+  QueueAdapterOptions,
 } from '../@types/app'
 
 export class BullMQAdapter implements QueueAdapter {
+  public readonly readOnlyMode: boolean
   private readonly LIMIT = 1000
 
   public get client(): Queue['client'] {
     return this.queue.client
   }
 
-  constructor(private queue: Queue) {}
+  constructor(
+    private queue: Queue,
+    options: Partial<QueueAdapterOptions> = {},
+  ) {
+    this.readOnlyMode = options.readOnlyMode === true
+  }
 
   public getName(): string {
     return this.queue.toKey('~')

--- a/src/routes/cleanAll.ts
+++ b/src/routes/cleanAll.ts
@@ -23,6 +23,10 @@ export const cleanAll: RequestHandler<RequestParams> = async (
       return res.status(404).send({
         error: 'Queue not found',
       })
+    } else if (queue.readOnlyMode) {
+      return res.status(405).send({
+        error: 'Method not allowed on read only queue',
+      })
     }
 
     await queue.clean(queueStatus as any, GRACE_TIME_MS)

--- a/src/routes/cleanJob.ts
+++ b/src/routes/cleanJob.ts
@@ -13,6 +13,10 @@ export const cleanJob: RequestHandler = async (req: Request, res: Response) => {
       return res.status(404).send({
         error: 'Queue not found',
       })
+    } else if (queue.readOnlyMode) {
+      return res.status(405).send({
+        error: 'Method not allowed on read only queue',
+      })
     }
 
     const job = await queue.getJob(id)

--- a/src/routes/promoteJob.ts
+++ b/src/routes/promoteJob.ts
@@ -16,6 +16,10 @@ export const promoteJob: RequestHandler = async (
       return res.status(404).send({
         error: 'Queue not found',
       })
+    } else if (queue.readOnlyMode) {
+      return res.status(405).send({
+        error: 'Method not allowed on read only queue',
+      })
     }
 
     const job = await queue.getJob(id)

--- a/src/routes/queues.ts
+++ b/src/routes/queues.ts
@@ -93,6 +93,7 @@ const getDataForQueues = async (
         name,
         counts: counts as Record<Status, number>,
         jobs: jobs.map(formatJob),
+        readOnlyMode: queue.readOnlyMode,
       }
     }),
   )

--- a/src/routes/retryAll.ts
+++ b/src/routes/retryAll.ts
@@ -12,6 +12,10 @@ export const retryAll: RequestHandler = async (req: Request, res: Response) => {
     const { queue } = bullBoardQueues[queueName]
     if (!queue) {
       return res.status(404).send({ error: 'queue not found' })
+    } else if (queue.readOnlyMode) {
+      return res.status(405).send({
+        error: 'Method not allowed on read only queue',
+      })
     }
 
     const jobs = await queue.getJobs(['failed'])

--- a/src/routes/retryJob.ts
+++ b/src/routes/retryJob.ts
@@ -13,6 +13,10 @@ export const retryJob: RequestHandler = async (req: Request, res: Response) => {
       return res.status(404).send({
         error: 'Queue not found',
       })
+    } else if (queue.readOnlyMode) {
+      return res.status(405).send({
+        error: 'Method not allowed on read only queue',
+      })
     }
 
     const job = await queue.getJob(id)

--- a/src/ui/components/JobCard/JobCard.tsx
+++ b/src/ui/components/JobCard/JobCard.tsx
@@ -10,6 +10,7 @@ import { Timeline } from './Timeline/Timeline'
 interface JobCardProps {
   job: AppJob
   status: Status
+  readOnlyMode: boolean
   actions: {
     promoteJob: () => Promise<void>
     retryJob: () => Promise<void>
@@ -17,7 +18,12 @@ interface JobCardProps {
   }
 }
 
-export const JobCard = ({ job, status, actions }: JobCardProps) => (
+export const JobCard = ({
+  job,
+  status,
+  actions,
+  readOnlyMode,
+}: JobCardProps) => (
   <div className={s.card}>
     <div className={s.sideInfo}>
       <span title={`#${job.id}`}>#{job.id}</span>
@@ -29,7 +35,7 @@ export const JobCard = ({ job, status, actions }: JobCardProps) => (
           {job.name}
           {job.attempts > 0 && <span>attempt #{job.attempts + 1}</span>}
         </h4>
-        <JobActions status={status} actions={actions} />
+        {!readOnlyMode && <JobActions status={status} actions={actions} />}
       </div>
       <div className={s.content}>
         <Details status={status} job={job} />

--- a/src/ui/components/QueuePage/QueuePage.tsx
+++ b/src/ui/components/QueuePage/QueuePage.tsx
@@ -27,11 +27,13 @@ export const QueuePage = ({
           selectedStatus={selectedStatus}
           onChange={actions.setSelectedStatuses}
         />
-        <QueueActions
-          queue={queue}
-          actions={actions}
-          status={selectedStatus[queue.name]}
-        />
+        {!queue.readOnlyMode && (
+          <QueueActions
+            queue={queue}
+            actions={actions}
+            status={selectedStatus[queue.name]}
+          />
+        )}
       </div>
       {queue.jobs.map((job) => (
         <JobCard
@@ -43,6 +45,7 @@ export const QueuePage = ({
             promoteJob: actions.promoteJob(queue?.name)(job),
             retryJob: actions.retryJob(queue?.name)(job),
           }}
+          readOnlyMode={queue?.readOnlyMode}
         />
       ))}
     </section>


### PR DESCRIPTION
This PR adds a `readOnlyMode` per queue.
In this mode, all queue & jobs related actions are removed from the UI.